### PR TITLE
WIP: update numeric operations to align with wasm primitives

### DIFF
--- a/FM-Net/fm-net.c
+++ b/FM-Net/fm-net.c
@@ -1,6 +1,7 @@
 #include <assert.h>
 #include <math.h>
 #include <stdint.h>
+#include <limits.h>
 
 #include "fm-net.h"
 
@@ -18,30 +19,82 @@ enum {
 };
 
 enum {
-  ADD,
-  SUB,
-  MUL,
-  DIV,
-  MOD,
-  POW,
-  AND,
-  BOR,
-  XOR,
-  NOT,
-  SHR,
-  SHL,
-  GTR,
-  LES,
-  EQL,
-  FADD,
-  FSUB,
-  FMUL,
-  FDIV,
-  FMOD,
-  FPOW,
-  ITOF,
-  FTOI,
+  EQ,      // equality
+  NE,      // not-equal
+  LT_S,    // signed less-than
+  LT_U,    // unsigned less-than
+  GT_S,    // signed greater-than
+  GT_U,    // unsigned greater-than
+  LE_S,    // signed less-than-or-equal
+  LE_U,    // unsigned less-than-or-equal
+  GE_S,    // signed greater-than-or-equal
+  GE_U,    // unsigned greater-than-or-equal
+  CLZ,     // count leading zeros, unary
+  CTZ,     // count trailing zeros, unary
+  POPCNT,  // count number of 1 bits, unary
+  SHL,     // shift left
+  SHR,     // unsigned shift right
+  SHR_S,   // signed shift right
+  ROTL,    // rotate left
+  ROTR,    // rotate right
+  AND,     // bitwise and
+  OR,      // bitwise or
+  XOR,     // bitwise xor
+  ADD,     // addition
+  SUB,     // subtraction
+  MUL,     // multiplication
+  DIV_S,   // signed division
+  DIV_U,   // unsigned division
+  REM_S,   // signed remainder
+  REM_U,   // unsigned remainder
+  FABS,    // absolute value, unary
+  FNEG,    // negation, unary
+  FCEIL,   // round upward, unary
+  FFLOOR,  // round downward, unary
+  FTRUNC,  // truncate, unary
+  FNRST,   // round to nearest, unary
+  FSQRT,   // square-root, unary
+  FADD,    // addition
+  FSUB,    // subtraction
+  FMUL,    // multiplication
+  FDIV,    // division
+  FMIN,    // minimum
+  FMAX,    // maximum
+  FCPYSGN, // copy sign value of first arg and sign of second arg
+  FEQ,     // equality
+  FNE,     // not-equal
+  FLT,     // less-than
+  FGT,     // greater-than
+  FLE,     // less-than-or-equal
+  FGE,     // greater-than-or-equal
+  EXT32_S, // signed extension of 32 bit numbers to 64 bit
+  FTOS,    // f64 to signed i64
+  FTOU,    // f64 to unsigned i64
+  STOF,    // signed i64 to f64
+  UTOF     // UNSIGNED I64 TO F64
 };
+
+uint64_t rotl(uint64_t a, uint64_t b) {
+  const uint64_t mask = CHAR_BIT*sizeof(b) - 1;
+  b &= mask;
+  return (a << b) | (a >> ((-b) & mask));
+}
+
+uint64_t rotr(uint64_t a, uint64_t b) {
+  const uint64_t mask = CHAR_BIT*sizeof(b) - 1;
+  b &= mask;
+  return (a >> b) | (a << ((-b) & 63));
+}
+
+//static uint64_t powi(uint64_t fst, uint64_t snd) {
+//  uint64_t res;
+//
+//  for (res = 1; snd; snd >>= 1, fst *= fst) {
+//    if (snd & 1)
+//      res *= fst;
+//  }
+//  return res;
+//}
 
 static uint64_t alloc_node(Net *net) {
   uint64_t addr;
@@ -65,20 +118,11 @@ static void queue(Net *net, uint64_t addr) {
   assert(addr % 4 == 0);
 }
 
-static uint64_t powi(uint64_t fst, uint64_t snd) {
-  uint64_t res;
-
-  for (res = 1; snd; snd >>= 1, fst *= fst) {
-    if (snd & 1)
-      res *= fst;
-  }
-  return res;
-}
-
 static void rewrite(Net *net, uint64_t a_addr) {
   uint64_t *nodes = net->nodes;
   union {
-    uint64_t i;
+    uint64_t u;
+    int64_t  s;
     double f;
   } res, fst, snd;
   uint64_t b_addr, c_addr, d_addr;
@@ -91,39 +135,70 @@ static void rewrite(Net *net, uint64_t a_addr) {
 
   switch (a_info & 3) {
   case NUM:
-    fst.i = a[0];
+    fst.u = a[0];
     switch (a_kind) {
     case OP1:
-      snd.i = a[1];
-      switch (a[3] >> 8) {
-      case ADD: res.i = fst.i + snd.i; break;
-      case SUB: res.i = fst.i - snd.i; break;
-      case MUL: res.i = fst.i * snd.i; break;
-      case DIV: res.i = fst.i / snd.i; break;
-      case MOD: res.i = fst.i % snd.i; break;
-      case POW: res.i = powi(fst.i, snd.i); break;
-      case AND: res.i = fst.i & snd.i; break;
-      case BOR: res.i = fst.i | snd.i; break;
-      case XOR: res.i = fst.i ^ snd.i; break;
-      case NOT: res.i = ~snd.i; break;
-      case SHR: res.i = fst.i >> snd.i; break;
-      case SHL: res.i = fst.i << snd.i; break;
-      case GTR: res.i = fst.i > snd.i; break;
-      case LES: res.i = fst.i < snd.i; break;
-      case EQL: res.i = fst.i == snd.i; break;
-      case FADD: res.f = fst.f + snd.f; break;
-      case FSUB: res.f = fst.f - snd.f; break;
-      case FMUL: res.f = fst.f * snd.f; break;
-      case FDIV: res.f = fst.f / snd.f; break;
-      case FMOD: res.f = fmod(fst.f, snd.f); break;
-      case FPOW: res.f = pow(fst.f, snd.f); break;
-      case ITOF: res.f = snd.i; break;
-      case FTOI: res.i = snd.f; break;
+      snd.u = a[1];
+    switch (a[3] >> 8) {
+      case EQ:      res.u = fst.u == snd.u; break;
+      case NE:      res.u = fst.u != snd.u; break;
+      case LT_S:    res.s = fst.s < snd.s; break;
+      case LT_U:    res.u = fst.u < snd.u; break;
+      case GT_S:    res.s = fst.s > snd.s; break;
+      case GT_U:    res.u = fst.u > snd.u; break;
+      case LE_S:    res.u = fst.s <= snd.s; break;
+      case LE_U:    res.u = fst.u <= snd.u; break;
+      case GE_S:    res.u = fst.u >= snd.u; break;
+      case GE_U:    res.u = fst.u >= snd.u; break;
+      case CLZ:     res.u = __builtin_clz(snd.u); break;
+      case CTZ:     res.u = __builtin_ctz(snd.u); break;
+      case POPCNT:  res.u = __builtin_popcount(snd.u); break;
+      case SHL:     res.u = fst.u << snd.u; break;
+      case SHR:     res.u = fst.u >> snd.u; break;
+      case SHR_S:   res.s = fst.s >> snd.u; break;
+      case ROTL:    res.u = rotl(fst.u, snd.u); break;
+      case ROTR:    res.u = rotr(fst.u, snd.u); break;
+      case AND:     res.u = fst.u & snd.u; break;
+      case  OR:     res.u = fst.u | snd.u; break;
+      case XOR:     res.u = fst.u ^ snd.u; break;
+      case ADD:     res.u = fst.u + snd.u; break;
+      case SUB:     res.u = fst.u - snd.u; break;
+      case MUL:     res.u = fst.u * snd.u; break;
+      case DIV_S:   res.s = fst.s / snd.s; break;
+      case DIV_U:   res.u = fst.u / snd.u; break;
+      case REM_S:   res.s = fst.s % snd.s; break;
+      case REM_U:   res.u = fst.u % snd.u; break;
+      case FABS:    res.f = fabs(snd.f); break;
+      case FNEG:    res.f = -1 * snd.f; break;
+      case FCEIL:   res.f = ceil(snd.f); break;
+      case FFLOOR:  res.f = floor(snd.f); break;
+      case FTRUNC:  res.f = trunc(snd.f); break;
+      case FNRST:   res.f = round(snd.f); break;
+      case FSQRT:   res.f = sqrt(snd.f); break;
+      case FADD:    res.f = fst.f + snd.f; break;
+      case FSUB:    res.f = fst.f - snd.f; break;
+      case FMUL:    res.f = fst.f * snd.f; break;
+      case FDIV:    res.f = fst.f / snd.f; break;
+      case FMIN:    res.f = fmin(fst.f, snd.f); break;
+      case FMAX:    res.f = fmax(fst.f, snd.f); break;
+      case FCPYSGN: res.f = copysign(fst.f, snd.f); break;
+      case FEQ:     res.u = fst.f == snd.f; break;
+      case FNE:     res.u = isunordered(fst.f,snd.f) ? 1 :
+                              islessgreater(fst.f, snd.f); break;
+      case FLT:     res.u = isless(fst.f, snd.f); break;
+      case FGT:     res.u = isgreater(fst.f, snd.f); break;
+      case FLE:     res.u = islessequal(fst.f, snd.f); break;
+      case FGE:     res.u = isgreaterequal(fst.f, snd.f); break;
+      //case EXT32_S:
+      case FTOS:   res.s = snd.f; break;
+      case FTOU:   res.u = snd.f; break;
+      case STOF:   res.f = snd.s; break;
+      case UTOF:   res.f = snd.u; break;
       /* unreachable */
-      default: res.i = 0; break;
+      default: res.u = 0; break;
       }
       if ((a[3] >> 4 & 3) == PTR) {
-        nodes[a[2]] = res.i;
+        nodes[a[2]] = res.u;
         nodes[a[2] | 3] |= NUM << (a[2] & 3) * 2;
         if ((a[2] & 3) == 0)
           queue(net, a[2]);
@@ -132,7 +207,7 @@ static void rewrite(Net *net, uint64_t a_addr) {
       break;
     case OP2:
       a[0] = a[1];
-      a[1] = fst.i;
+      a[1] = fst.u;
       a[3] = OP1 << 6 | NUM << 2 | (a[3] >> 2 & 3) |
              (a[3] & ~(3 << 6 | 3 << 0 | 3 << 2));
       if ((a[3] & 3) == PTR)
@@ -142,13 +217,13 @@ static void rewrite(Net *net, uint64_t a_addr) {
       break;
     case NOD:
       if ((a[3] >> 2 & 3) == PTR) {
-        nodes[a[1]] = fst.i;
+        nodes[a[1]] = fst.u;
         nodes[a[1] | 3] |= NUM << (a[1] & 3) * 2;
         if ((a[1] & 3) == 0)
           queue(net, a[1]);
       }
       if ((a[3] >> 4 & 3) == PTR) {
-        nodes[a[2]] = fst.i;
+        nodes[a[2]] = fst.u;
         nodes[a[2] | 3] |= NUM << (a[2] & 3) * 2;
         if ((a[2] & 3) == 0)
           queue(net, a[2]);
@@ -160,7 +235,7 @@ static void rewrite(Net *net, uint64_t a_addr) {
       a[0] = a[1];
       a[3] = NOD << 6 | (a[3] >> 2 & 3) | (a[3] & ~0xff);
       nodes[a[0]] &= ~3;
-      if (fst.i) {
+      if (fst.u) {
         a[1] = a[2];
         a[3] |= (a_info >> 2 & 3 << 2) | ERA << 4;
         nodes[a[1]] ^= 3;

--- a/FM-Net/fm-net.c
+++ b/FM-Net/fm-net.c
@@ -4,6 +4,7 @@
 #include <limits.h>
 
 #include "fm-net.h"
+//#include "emscripten.h"
 
 enum {
   PTR,
@@ -19,16 +20,16 @@ enum {
 };
 
 enum {
-  EQ,      // equality
-  NE,      // not-equal
-  LT_S,    // signed less-than
-  LT_U,    // unsigned less-than
-  GT_S,    // signed greater-than
-  GT_U,    // unsigned greater-than
-  LE_S,    // signed less-than-or-equal
-  LE_U,    // unsigned less-than-or-equal
-  GE_S,    // signed greater-than-or-equal
-  GE_U,    // unsigned greater-than-or-equal
+  EQ,     // equality
+  NE,     // not-equal
+  LT_S,   // signed less-than
+  LT_U,   // unsigned less-than
+  GT_S,   // signed greater-than
+  GT_U,   // unsigned greater-than
+  LE_S,   // signed less-than-or-equal
+  LE_U,   // unsigned less-than-or-equal
+  GE_S,   // signed greater-than-or-equal
+  GE_U,   // unsigned greater-than-or-equal
   CLZ,     // count leading zeros, unary
   CTZ,     // count trailing zeros, unary
   POPCNT,  // count number of 1 bits, unary
@@ -71,21 +72,73 @@ enum {
   FTOS,    // f64 to signed i64
   FTOU,    // f64 to unsigned i64
   STOF,    // signed i64 to f64
-  UTOF     // UNSIGNED I64 TO F64
+  UTOF     // unsigned i64 to f64
 };
 
-uint64_t rotl(uint64_t a, uint64_t b) {
+uint64_t _eq(uint64_t a, uint64_t b) { return a == b; }
+uint64_t _ne(uint64_t a, uint64_t b) { return a != b; }
+uint64_t _lt_s(int64_t a, int64_t b) { return a < b; }
+uint64_t _gt_s(int64_t a, int64_t b) { return a > b; }
+uint64_t _le_s(int64_t a, int64_t b) { return a <= b; }
+uint64_t _ge_s(int64_t a, int64_t b) { return a >= b; }
+uint64_t _lt_u(uint64_t a, uint64_t b) { return a < b; }
+uint64_t _gt_u(uint64_t a, uint64_t b) { return a > b; }
+uint64_t _le_u(uint64_t a, uint64_t b) { return a <= b; }
+uint64_t _ge_u(uint64_t a, uint64_t b) { return a >= b; }
+uint64_t _clz(uint64_t a, uint64_t b) { return __builtin_clzll(b); }
+uint64_t _ctz(uint64_t a, uint64_t b) { return __builtin_ctzll(b); }
+uint64_t _popcnt(uint64_t a,uint64_t b) { return __builtin_popcountll(b); }
+uint64_t _shl(uint64_t a, uint64_t b) { return a << b; }
+uint64_t _shr(uint64_t a, uint64_t b) { return a >> b; }
+int64_t _shr_s(int64_t a, uint64_t b) { return a >> b; }
+uint64_t _and(uint64_t a, uint64_t b) { return a & b; }
+uint64_t _or(uint64_t a, uint64_t b) { return a | b; }
+uint64_t _xor(uint64_t a, uint64_t b) { return a ^ b; }
+uint64_t _add(uint64_t a, uint64_t b) { return a + b; }
+uint64_t _sub(uint64_t a, uint64_t b) { return a - b; }
+uint64_t _mul(uint64_t a, uint64_t b) { return a * b; }
+int64_t _div_s(int64_t a, int64_t b) { return a / b; }
+uint64_t _div_u(uint64_t a, uint64_t b) { return a / b; }
+int64_t _rem_s(int64_t a, int64_t b) { return a % b; }
+uint64_t _rem_u(uint64_t a, uint64_t b) { return a % b; }
+double _fabs(double a, double b) { return fabs(b); }
+double _fneg(double a, double b) { return -1 * b; }
+double _fceil(double a, double b) { return ceil(b); }
+double _ffloor(double a, double b) { return floor(b); }
+double _ftrunc(double a, double b) { return trunc(b); }
+double _fnrst(double a, double b) { return round(b); }
+double _fsqrt(double a, double b) { return sqrt(b); }
+double _fadd(double a, double b) { return a + b; }
+double _fsub(double a, double b) { return a - b; }
+double _fmul(double a, double b) { return a * b; }
+double _fdiv(double a, double b) { return a / b; }
+double _fmin(double a, double b) { return fmin(a,b); }
+double _fmax(double a, double b) { return fmax(a,b); }
+double _fcpysgn(double a, double b) { return copysign(a,b); }
+uint64_t _feq(double a, double b) { return a == b; }
+uint64_t _flt(double a, double b) { return isless(a,b); }
+uint64_t _fgt(double a, double b) { return isgreater(a,b); }
+uint64_t _fle(double a, double b) { return islessequal(a,b); }
+uint64_t _fge(double a, double b) { return isgreaterequal(a,b); }
+int64_t _ftos(double a, double b) { return (int64_t) b; }
+uint64_t _ftou(double a, double b) { return (uint64_t) b; }
+double _stof(int64_t a, int64_t b) { return (double) b; }
+double _utof(uint64_t a, uint64_t b) { return (double) b; }
+
+uint64_t _fne(double a, double b) {
+  return isunordered(a,b) ? 1 : islessgreater(a,b);
+}
+
+uint64_t _rotl(uint64_t a, uint64_t b) {
   const uint64_t mask = CHAR_BIT*sizeof(b) - 1;
   b &= mask;
   return (a << b) | (a >> ((-b) & mask));
 }
-
-uint64_t rotr(uint64_t a, uint64_t b) {
+uint64_t _rotr(uint64_t a, uint64_t b) {
   const uint64_t mask = CHAR_BIT*sizeof(b) - 1;
   b &= mask;
   return (a >> b) | (a << ((-b) & 63));
 }
-
 //static uint64_t powi(uint64_t fst, uint64_t snd) {
 //  uint64_t res;
 //
@@ -140,60 +193,59 @@ static void rewrite(Net *net, uint64_t a_addr) {
     case OP1:
       snd.u = a[1];
     switch (a[3] >> 8) {
-      case EQ:      res.u = fst.u == snd.u; break;
-      case NE:      res.u = fst.u != snd.u; break;
-      case LT_S:    res.s = fst.s < snd.s; break;
-      case LT_U:    res.u = fst.u < snd.u; break;
-      case GT_S:    res.s = fst.s > snd.s; break;
-      case GT_U:    res.u = fst.u > snd.u; break;
-      case LE_S:    res.u = fst.s <= snd.s; break;
-      case LE_U:    res.u = fst.u <= snd.u; break;
-      case GE_S:    res.u = fst.u >= snd.u; break;
-      case GE_U:    res.u = fst.u >= snd.u; break;
-      case CLZ:     res.u = __builtin_clz(snd.u); break;
-      case CTZ:     res.u = __builtin_ctz(snd.u); break;
-      case POPCNT:  res.u = __builtin_popcount(snd.u); break;
-      case SHL:     res.u = fst.u << snd.u; break;
-      case SHR:     res.u = fst.u >> snd.u; break;
-      case SHR_S:   res.s = fst.s >> snd.u; break;
-      case ROTL:    res.u = rotl(fst.u, snd.u); break;
-      case ROTR:    res.u = rotr(fst.u, snd.u); break;
-      case AND:     res.u = fst.u & snd.u; break;
-      case  OR:     res.u = fst.u | snd.u; break;
-      case XOR:     res.u = fst.u ^ snd.u; break;
-      case ADD:     res.u = fst.u + snd.u; break;
-      case SUB:     res.u = fst.u - snd.u; break;
-      case MUL:     res.u = fst.u * snd.u; break;
-      case DIV_S:   res.s = fst.s / snd.s; break;
-      case DIV_U:   res.u = fst.u / snd.u; break;
-      case REM_S:   res.s = fst.s % snd.s; break;
-      case REM_U:   res.u = fst.u % snd.u; break;
-      case FABS:    res.f = fabs(snd.f); break;
-      case FNEG:    res.f = -1 * snd.f; break;
-      case FCEIL:   res.f = ceil(snd.f); break;
-      case FFLOOR:  res.f = floor(snd.f); break;
-      case FTRUNC:  res.f = trunc(snd.f); break;
-      case FNRST:   res.f = round(snd.f); break;
-      case FSQRT:   res.f = sqrt(snd.f); break;
-      case FADD:    res.f = fst.f + snd.f; break;
-      case FSUB:    res.f = fst.f - snd.f; break;
-      case FMUL:    res.f = fst.f * snd.f; break;
-      case FDIV:    res.f = fst.f / snd.f; break;
-      case FMIN:    res.f = fmin(fst.f, snd.f); break;
-      case FMAX:    res.f = fmax(fst.f, snd.f); break;
-      case FCPYSGN: res.f = copysign(fst.f, snd.f); break;
-      case FEQ:     res.u = fst.f == snd.f; break;
-      case FNE:     res.u = isunordered(fst.f,snd.f) ? 1 :
-                              islessgreater(fst.f, snd.f); break;
-      case FLT:     res.u = isless(fst.f, snd.f); break;
-      case FGT:     res.u = isgreater(fst.f, snd.f); break;
-      case FLE:     res.u = islessequal(fst.f, snd.f); break;
-      case FGE:     res.u = isgreaterequal(fst.f, snd.f); break;
+      case EQ:      res.u = _eq(fst.u,snd.u); break;
+      case NE:      res.u = _ne(fst.u,snd.u); break;
+      case LT_S:    res.s = _lt_s(fst.s,snd.s); break;
+      case LT_U:    res.u = _lt_u(fst.u,snd.u); break;
+      case GT_S:    res.s = _gt_s(fst.s,snd.s); break;
+      case GT_U:    res.u = _gt_u(fst.u,snd.u); break;
+      case LE_S:    res.u = _le_s(fst.s,snd.s); break;
+      case LE_U:    res.u = _le_u(fst.u,snd.u); break;
+      case GE_S:    res.u = _ge_s(fst.u,snd.u); break;
+      case GE_U:    res.u = _ge_u(fst.u,snd.u); break;
+      case CLZ:     res.u = _clz(fst.u,snd.u); break;
+      case CTZ:     res.u = _ctz(fst.u,snd.u); break;
+      case POPCNT:  res.u = _popcnt(fst.u,snd.u); break;
+      case SHL:     res.u = _shl(fst.u,snd.u); break;
+      case SHR:     res.u = _shr(fst.u,snd.u); break;
+      case SHR_S:   res.s = _shr_s(fst.s,snd.u); break;
+      case ROTL:    res.u = _rotl(fst.u,snd.u); break;
+      case ROTR:    res.u = _rotr(fst.u,snd.u); break;
+      case AND:     res.u = _and(fst.u,snd.u); break;
+      case  OR:     res.u = _or(fst.u,snd.u); break;
+      case XOR:     res.u = _xor(fst.u,snd.u); break;
+      case ADD:     res.u = _add(fst.u,snd.u); break;
+      case SUB:     res.u = _sub(fst.u,snd.u); break;
+      case MUL:     res.u = _mul(fst.u,snd.u); break;
+      case DIV_S:   res.s = _div_s(fst.s,snd.s); break;
+      case DIV_U:   res.u = _div_u(fst.u,snd.u); break;
+      case REM_S:   res.s = _rem_s(fst.s,snd.s); break;
+      case REM_U:   res.u = _rem_u(fst.u,snd.u); break;
+      case FABS:    res.f = _fabs(fst.f,snd.f); break;
+      case FNEG:    res.f = _fneg(fst.f,snd.f); break;
+      case FCEIL:   res.f = _fceil(fst.f,snd.f); break;
+      case FFLOOR:  res.f = _ffloor(fst.f,snd.f); break;
+      case FTRUNC:  res.f = _ftrunc(fst.f,snd.f); break;
+      case FNRST:   res.f = _fnrst(fst.f,snd.f); break;
+      case FSQRT:   res.f = _fsqrt(fst.f,snd.f); break;
+      case FADD:    res.f = _fadd(fst.f,snd.f); break;
+      case FSUB:    res.f = _fsub(fst.f,snd.f); break;
+      case FMUL:    res.f = _fmul(fst.f,snd.f); break;
+      case FDIV:    res.f = _fdiv(fst.f,snd.f); break;
+      case FMIN:    res.f = _fmin(fst.f, snd.f); break;
+      case FMAX:    res.f = _fmax(fst.f, snd.f); break;
+      case FCPYSGN: res.f = _fcpysgn(fst.f, snd.f); break;
+      case FEQ:     res.u = _fne(fst.f,snd.f); break;
+      case FNE:     res.u = _fne(fst.f,snd.f); break;
+      case FLT:     res.u = _flt(fst.f,snd.f); break;
+      case FGT:     res.u = _fgt(fst.f,snd.f); break;
+      case FLE:     res.u = _fle(fst.f,snd.f); break;
+      case FGE:     res.u = _fge(fst.f,snd.f); break;
       //case EXT32_S:
-      case FTOS:   res.s = snd.f; break;
-      case FTOU:   res.u = snd.f; break;
-      case STOF:   res.f = snd.s; break;
-      case UTOF:   res.f = snd.u; break;
+      case FTOS:   res.s = _ftos(fst.f,snd.f); break;
+      case FTOU:   res.u = _ftou(fst.f,snd.f); break;
+      case STOF:   res.f = _stof(fst.s,snd.s); break;
+      case UTOF:   res.f = _utof(fst.u,snd.u); break;
       /* unreachable */
       default: res.u = 0; break;
       }


### PR DESCRIPTION
I've added numeric operations to make this compatible with the WASM primitives exported by https://github.com/moonad/Formality/blob/jcb/wasm-num/src/fm-num.js.

I am not confident every operation matches the WASM behavior under all circumstances. We should choose between:

1. Doing extensive testing/modification of the spec to make sure we're confident that every operation has the same behavior.
2. Figuring out a way to link the `ops.wasm` module with `fm-net.wasm`
3. Factoring out each operation into its own function in the C source and exporting those functions through wasm rather than using handwritten `.wat`

My feeling is that #1 is the best way to go so that we get a good sense of how much work it takes per operation to ensure correctness. If some operations feel particularly unportable, we should consider removing them